### PR TITLE
Moderatior is not shown in settings when not in use

### DIFF
--- a/R/create_auth_tables.R
+++ b/R/create_auth_tables.R
@@ -207,6 +207,9 @@ create_auth_tables = function(auth_config_path) {
   # Set as admin
   dt_first_user[, admin := 1]
 
+  # Set the time and date of user creation
+  dt_first_user[, c("date_created", "last_password_change") := Sys.time()]
+
   # If using moderators, set the user as not a modorator
   if (auth_config$table_cofig$moderator$use_moderatior) {
     dt_first_user[, moderator := 1]

--- a/R/settings_tab.R
+++ b/R/settings_tab.R
@@ -131,7 +131,14 @@ render_settings_page = function(input, output, session, auth,
   # Extract just the viewable columns,
   viewable_columns = setdiff(
     x = names(auth$table_cofig[viewable]),
-    y = c("password", "admin", changeable_columns))
+    y = c("password", "admin", "date_created", "last_password_change", changeable_columns))
+
+  # Remove moderator from changeable_columns if user moderaror is false
+  if (!shiny::isTruthy(auth$table_cofig$moderator$use_moderatior)) {
+    viewable_columns = setdiff(
+      x = viewable_columns,
+      y = c("moderator"))
+  }
 
   ns = session$ns
 
@@ -275,7 +282,17 @@ render_settings_box = function(input, output, session, auth,
       title = auth$table_cofig[[column_name]]$human_name,
       dt_user[, ..column_name])
 
-  } else if (column_name %in% c("moderator", "admin")) {
+  } else if (column_name == "moderator" &
+             shiny::isTruthy(auth$table_cofig$moderator$use_moderatior)) {
+    ui = shinydashboard::box(
+      width = 4,
+      title = auth$table_cofig[[column_name]]$human_name,
+      shiny::checkboxInput(
+        inputId = ns(column_name),
+        label   = NULL,
+        value   = as.logical(dt_user[, ..column_name])))
+
+  }else if (column_name == "admin") {
     ui = shinydashboard::box(
       width = 4,
       title = auth$table_cofig[[column_name]]$human_name,

--- a/minimum_example/server.R
+++ b/minimum_example/server.R
@@ -2,15 +2,8 @@ library(shiny)
 library(shinydashboard)
 library(ShinyBasicAuth)
 
-# The following line must have been run:
-ShinyBasicAuth::create_auth_tables(auth_config_path = "./auth_conf.yaml")
-
-### Call the sheppey auth server
-ShinyBasicAuth::auth_server(
-  server      = server_post_auth,
-  config_path = "./auth_conf.yaml")
-
-
+# # The following line must have been run:
+# ShinyBasicAuth::create_auth_tables(auth_config_path = "~/.auth_example.yaml")
 
 ### Server funciton to run when the user is logged in
 server_post_auth = function(input, output, session, auth) {
@@ -48,3 +41,8 @@ server_post_auth = function(input, output, session, auth) {
     )
   })
 }
+
+### Call the sheppey auth server
+ShinyBasicAuth::auth_server(
+  server      = server_post_auth,
+  config_path = "~/.auth_example.yaml")


### PR DESCRIPTION
There was a bug that caused an the settengs page to always try
to show the moderator box on the settings page, even when it was
not being used in auth.  This has been fixed so that it is not
shown if the use modorators flag is set to false.

There has also been a change to the boxes that are shown in the
settings tab, not the date created and last password change will
not be shown to the user.